### PR TITLE
Added mappings for deprecated archetypes

### DIFF
--- a/medical_data/cluster/Dosage_v2.yml
+++ b/medical_data/cluster/Dosage_v2.yml
@@ -1,0 +1,22 @@
+archetype_id: "openEHR-EHR-CLUSTER.dosage.v2"
+
+mappings:
+  - type: "DrugExposure"
+    concept_id:
+      alternatives:
+        - path: "../items[at0020]"
+    drug_exposure_start_date:
+      alternatives:
+        - path: "../items[at0043]"
+        - path: "../../"
+    drug_exposure_end_date:
+      alternatives:
+        - path: "../items[at0043]"
+        - path: "../../"
+    quantity:
+      optional: true
+      alternatives:
+        - multiplication:
+            - path: "/items[at0144]"
+            - path: "/items[at0164]"
+        - path: "/items[at0144]"

--- a/medical_data/instruction/Medication_order_v3.yml
+++ b/medical_data/instruction/Medication_order_v3.yml
@@ -1,0 +1,18 @@
+archetype_id: "openEHR-EHR-INSTRUCTION.medication_order.v3"
+
+mappings:
+  - type: "DrugExposure"
+    base_path: "activities[at0001]"
+    concept_id:
+      alternatives:
+        - path: "description[at0002]/items[at0070]"
+    drug_exposure_start_date:
+      alternatives:
+        - path: "description[at0002]/items[at0113]/items[at0012]"
+    drug_exposure_end_date:
+      alternatives:
+        - path: "description[at0002]/items[at0113]/items[at0013]"
+    route_concept_id:
+      optional: true
+      alternatives:
+        - path: "description[at0002]/items[at0091]"


### PR DESCRIPTION
Added mappings to dosage.v2 and medication_order.v3. Even with the version change in CKM, same mappings are still valid